### PR TITLE
v13 support: add required 'id' attribute to module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,4 +1,5 @@
 {
+  "id": "investigation-board",
   "name": "investigation-board",
   "title": "Investigation Board",
   "description": "A Foundry VTT module that lets everyone create, edit, and move sticky and photo notes on the scene as collaborative investigation tools.",


### PR DESCRIPTION
In order to get my board displaying in Foundry v13, I've had to add the `id` attribute to `module.json`, otherwise foundry refuses to register the module. Related to #13

Without this change, the module cannot be installed on a v13 system. Once I add it, the module installs (and the contents of my board appear - not perfect because I can't find the button to create a new note, but at least the boards don't disappear!)